### PR TITLE
Set CMake build config to release with debug info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 # refer to the root source directory of the project as ${HELLO_SOURCE_DIR} and
 # to the root binary directory of the project as ${HELLO_BINARY_DIR}.
 cmake_minimum_required (VERSION 3.8)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
+set(CMAKE_CXX_STANDARD 17)
 
 INCLUDE_DIRECTORIES(
     src/main
@@ -20,13 +22,19 @@ set(SOURCES
 )
 
 if(MSVC)
-    add_compile_options("/W4" "/std:c++17" "/Za" "$<$<CONFIG:RELEASE>:/O2>")
+    add_compile_options("/W4" "/Za" "$<$<CONFIG:RELEASE>:/O2>")
 else()
     set(CMAKE_C_COMPILER "clang")
     set(CMAKE_CXX_COMPILER "clang++")
-    add_compile_options("-Wall" "$<$<CONFIG:RELEASE>:-O3>")
-    add_compile_options("-std=c++17" "-Wno-deprecated-declarations")
-    add_compile_options("-Wno-microsoft-exception-spec")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O3 -g")
+    string(CONCAT CMAKE_CXX_FLAGS
+        "-Wall -Wextra "
+        "-Wno-deprecated-declarations "
+        "-Wno-microsoft-exception-spec "
+        # Cargo culted from default CMAKE flags, see
+        # https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros?view=msvc-160
+        "-D_DLL=1 -D_MT=1"
+    )
     # if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     #     add_compile_options("-stdlib=libc++")
     # else()
@@ -39,4 +47,4 @@ endif()
 # cause another cmake executable to run. The same process will walk through
 # the project's entire directory structure.
 add_library(d3d11 SHARED ${SOURCES})
-
+target_link_libraries(d3d11 "-lmsvcrt")

--- a/src/d3d11/d3d11.cpp
+++ b/src/d3d11/d3d11.cpp
@@ -22,8 +22,8 @@ void hook_exports()
     wrapped_dll = LoadLibraryA(dll_path.c_str());
 
     log_g->debug("Locating exports... ");
-    int count = 0;
-    for (int i = 0; i < d3d11::func_count; i++)
+    size_t count = 0;
+    for (size_t i = 0; i < d3d11::func_count; i++)
     {
         FARPROC func = GetProcAddress(wrapped_dll, func_names[i]);
         if (func)

--- a/src/main/dllmain.h
+++ b/src/main/dllmain.h
@@ -51,6 +51,10 @@ constexpr const char* build = __DATE__ "   " __TIME__;
 
 inline BOOL on_process_attach(HMODULE h_module, LPVOID lp_reserved)
 {
+    // Args are unused in some configs, suppress warnings.
+    (void)h_module;
+    (void)lp_reserved;
+
     d3d11::hook_exports();
 
     WRAPPER_ON_PROCESS_ATTACH_GLOBAL_NS(h_module, lp_reserved);
@@ -60,6 +64,10 @@ inline BOOL on_process_attach(HMODULE h_module, LPVOID lp_reserved)
 
 inline BOOL on_process_detach(HMODULE h_module, LPVOID lp_reserved)
 {
+    // Args are unused in some configs, suppress warnings.
+    (void)h_module;
+    (void)lp_reserved;
+
     WRAPPER_ON_PROCESS_DETACH_GLOBAL_NS(h_module, lp_reserved);
 
     return BOOL(!!FreeLibrary(d3d11::wrapped_dll));
@@ -67,12 +75,20 @@ inline BOOL on_process_detach(HMODULE h_module, LPVOID lp_reserved)
 
 inline BOOL on_thread_attach(HMODULE h_module, LPVOID lp_reserved)
 {
+    // Args are unused in some configs, suppress warnings.
+    (void)h_module;
+    (void)lp_reserved;
+
     WRAPPER_ON_THREAD_ATTACH_GLOBAL_NS(h_module, lp_reserved);
     return TRUE;
 }
 
 inline BOOL on_thread_detach(HMODULE h_module, LPVOID lp_reserved)
 {
+    // Args are unused in some configs, suppress warnings.
+    (void)h_module;
+    (void)lp_reserved;
+
     WRAPPER_ON_THREAD_DETACH_GLOBAL_NS(h_module, lp_reserved);
     return TRUE;
 }


### PR DESCRIPTION
- Set CMake config to `RelWithDebInfo`
- Fix up C++ flags to `-O3 -g`
- Add additional warning flags and fix up resulting warnings

The results look pretty great! Even without any sort of LTO, the wrapped D3D11 calls are a test and jump:
```
?DrawIndexed@D3D11DeviceContextWrapper@@UEAAXIIH@Z:
  0000000180032170: F6 05 01 88 01 00  test        byte ptr [?render_enabled_g@@3U?$atomic@_N@std@@A],1
                    01
  0000000180032177: 75 01              jne         000000018003217A
  0000000180032179: C3                 ret
  000000018003217A: 48 8B 49 08        mov         rcx,qword ptr [rcx+8]
  000000018003217E: 48 8B 01           mov         rax,qword ptr [rcx]
  0000000180032181: 48 8B 40 60        mov         rax,qword ptr [rax+60h]
  0000000180032185: 48 FF E0           jmp         rax
  0000000180032188: 0F 1F 84 00 00 00  nop         dword ptr [rax+rax]
                    00 00
```

I didn't test this with a MSVC generator - let me know if you want to double-check that it's happy with these changes.